### PR TITLE
Don't attempt cloning on symbols for inheritable attribute values.

### DIFF
--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -14,7 +14,7 @@ module Uber
 
     def self.inherit_for(klass, name)
       return unless klass.superclass.respond_to?(name) and value = klass.superclass.send(name)
-      value.clone # only do this once.
+      value.is_a?(Symbol) ? value : value.clone
     end
   end
 

--- a/test/inheritable_attr_test.rb
+++ b/test/inheritable_attr_test.rb
@@ -7,8 +7,13 @@ class InheritableAttrTest < MiniTest::Spec
       Class.new(Object) do
         extend Uber::InheritableAttribute
         inheritable_attr :drinks
+        inheritable_attr :glass
       end
     }
+
+    def assert_nothing_raised(*)
+      yield
+    end
 
     it "provides a reader with empty inherited attributes, already" do
       assert_equal nil, subject.drinks
@@ -49,6 +54,13 @@ class InheritableAttrTest < MiniTest::Spec
 
       subklass.drinks = [:merlot] # we only want merlot explicitely.
       assert_equal [:merlot], subklass.drinks # no :cabernet, here
+    end
+
+    it 'does not attempt to clone symbols' do
+      subject.glass = :highball
+
+      subklass = Class.new(subject)
+      assert_nothing_raised { subklass.glass }
     end
   end
 end


### PR DESCRIPTION
This fixes a small bug where if your value is a symbol, you'll raise an exception when accessing it on a subclass.
