### PR TITLE
Fix for Ruby 2.2

### DIFF
--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -22,7 +22,7 @@ module Uber
 
     class Clone
       # The second argument allows injecting more types.
-      def self.call(value, uncloneable=uncloneable)
+      def self.call(value, uncloneable=uncloneable())
         uncloneable.each { |klass| return value if value.kind_of?(klass) }
         value.clone
       end


### PR DESCRIPTION
The behavor of method as default argument has been changed in Ruby2.2.
see: https://bugs.ruby-lang.org/issues/10314
