### PR TITLE
changed block to lambda to allow return in builds

### DIFF
--- a/lib/uber/builder.rb
+++ b/lib/uber/builder.rb
@@ -80,7 +80,9 @@ module Uber
       #
       # In your view #cell will instantiate the right cell for you now.
       def builds(&block)
-        builders << block
+        obj = Object.new
+        obj.define_singleton_method(:_, &block)
+        builders << obj.method(:_).to_proc
       end
 
       def class_builder

--- a/lib/uber/builder.rb
+++ b/lib/uber/builder.rb
@@ -79,10 +79,8 @@ module Uber
       #   end
       #
       # In your view #cell will instantiate the right cell for you now.
-      def builds(&block)
-        obj = Object.new
-        obj.define_singleton_method(:_, &block)
-        builders << obj.method(:_).to_proc
+      def builds(proc=nil, &block)
+        builders << (proc.kind_of?(Proc) ? proc : block)
       end
 
       def class_builder

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -56,4 +56,20 @@ class BuilderTest < MiniTest::Spec
   it { Play.build({}).must_be_instance_of Play }
   it { Play.build({evergreen: true}).must_be_instance_of Play }
   it { Play.build({hit: true}).must_be_instance_of Play }
+
+  # test return from builds
+  class Boomerang
+    include Uber::Builder
+
+    builds do |options|
+      return Song if options[:hit]
+    end
+
+    def self.build(options)
+      class_builder.call(options).new
+    end
+  end
+
+  it { Boomerang.build({}).must_be_instance_of Boomerang }
+  it { Boomerang.build({hit: true}).must_be_instance_of Song }
 end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -61,7 +61,7 @@ class BuilderTest < MiniTest::Spec
   class Boomerang
     include Uber::Builder
 
-    builds do |options|
+    builds ->(options) do
       return Song if options[:hit]
     end
 


### PR DESCRIPTION
In the trailblazer book there is an example which uses return, but the current code throws a LocalJumpError if you use them.