### PR TITLE
add "clone: false" option to InheritableAttr

### DIFF
--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -1,6 +1,7 @@
 module Uber
   module InheritableAttr
-    def inheritable_attr(name)
+
+    def inheritable_attr(name, options={})
       instance_eval %Q{
         def #{name}=(v)
           @#{name} = v
@@ -10,14 +11,29 @@ module Uber
           return @#{name} if instance_variable_defined?(:@#{name})
           @#{name} = InheritableAttribute.inherit_for(self, :#{name})
         end
+
+        unless respond_to?(:_cloneability)
+          def _cloneability
+            @_cloneability ||= Hash.new {|k| true}
+          end
+        end
+
+        _cloneability[:#{name}] = #{options.fetch(:clone, true)}
       }
     end
 
     def self.inherit_for(klass, name)
       return unless klass.superclass.respond_to?(name)
 
-      value = klass.superclass.send(name) # could be nil.
-      Clone.(value) # this could be dynamic, allowing other inheritance strategies.
+      value = klass.superclass.send(name) # could be nil
+      clonable = klass.superclass._cloneability[name]
+      klass._cloneability[name] = clonable
+
+      if clonable
+        Clone.(value) # this could be dynamic, allowing other inheritance strategies.
+      else
+        Clone.(value, Array(value.class))
+      end
     end
 
     class Clone
@@ -28,7 +44,7 @@ module Uber
       end
 
       def self.uncloneable
-        [Symbol, TrueClass, FalseClass, NilClass, Numeric]
+        [Symbol, TrueClass, FalseClass, NilClass]
       end
     end
   end

--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -9,27 +9,17 @@ module Uber
 
         def #{name}
           return @#{name} if instance_variable_defined?(:@#{name})
-          @#{name} = InheritableAttribute.inherit_for(self, :#{name})
+          @#{name} = InheritableAttribute.inherit_for(self, :#{name}, #{options})
         end
-
-        unless respond_to?(:_cloneability)
-          def _cloneability
-            @_cloneability ||= Hash.new {|k| true}
-          end
-        end
-
-        _cloneability[:#{name}] = #{options.fetch(:clone, true)}
       }
     end
 
-    def self.inherit_for(klass, name)
+    def self.inherit_for(klass, name, options={})
       return unless klass.superclass.respond_to?(name)
 
       value = klass.superclass.send(name) # could be nil
-      clonable = klass.superclass._cloneability[name]
-      klass._cloneability[name] = clonable
 
-      if clonable
+      if options.fetch(:clone, true)
         Clone.(value) # this could be dynamic, allowing other inheritance strategies.
       else
         Clone.(value, Array(value.class))

--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -28,7 +28,7 @@ module Uber
       end
 
       def self.uncloneable
-        [Symbol, TrueClass, FalseClass, NilClass]
+        [Symbol, TrueClass, FalseClass, NilClass, Numeric]
       end
     end
   end

--- a/test/inheritable_attr_test.rb
+++ b/test/inheritable_attr_test.rb
@@ -8,6 +8,7 @@ class InheritableAttrTest < MiniTest::Spec
         extend Uber::InheritableAttribute
         inheritable_attr :drinks
         inheritable_attr :glass
+        inheritable_attr :guests
       end
     }
 
@@ -37,15 +38,19 @@ class InheritableAttrTest < MiniTest::Spec
 
     it "inherits attributes" do
       subject.drinks = [:cabernet]
+      subject.guests = 2
 
       subklass_a = Class.new(subject)
       subklass_a.drinks << :becks
+      subklass_a.guests = 13
 
       subklass_b = Class.new(subject)
 
       assert_equal [:cabernet],         subject.drinks
       assert_equal [:cabernet, :becks], subklass_a.drinks
       assert_equal [:cabernet],         subklass_b.drinks
+      assert_equal 2,                   subklass_b.guests
+      assert_equal 13,                subklass_a.guests
     end
 
     it "does not inherit attributes if we set explicitely" do

--- a/test/inheritable_attr_test.rb
+++ b/test/inheritable_attr_test.rb
@@ -8,7 +8,7 @@ class InheritableAttrTest < MiniTest::Spec
         extend Uber::InheritableAttribute
         inheritable_attr :drinks
         inheritable_attr :glass
-        inheritable_attr :guests
+        inheritable_attr :guests, clone: false
       end
     }
 


### PR DESCRIPTION
I'm getting `TypeError: can't clone Fixnum` (and related, like `Float`) while using `inheritable_attr`. The list of uncloneable classes is still probably not exhaustive, but I added `Numeric` to it.