### PR TITLE
add deprecation message for automatic uncloneable detection

### DIFF
--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -26,7 +26,13 @@ module Uber
     class Clone
       # The second argument allows injecting more types.
       def self.call(value, uncloneable=uncloneable())
-        uncloneable.each { |klass| return value if value.kind_of?(klass) }
+        uncloneable.each do |klass| 
+          if value.kind_of?(klass)
+            STDERR.puts "[DEPRECATION WARNING] You are relying on automatic uncloneable classes detection, which will be removed. Please, use 'clone: false' with your inheritable_attr definition instead."
+            return value
+          end
+        end
+
         value.clone
       end
 


### PR DESCRIPTION
I added deprecation message like you asked here: https://github.com/apotonick/uber/commit/314188d53e16ca7bbc3db491c37ff25ca4749c3f

However, now tests output is full of them. Not sure what to do with it. Remove those tests, as they are testing soon-to-be-removed behaviour?