### PR TITLE
Adding support for deeply nested Builders.

### DIFF
--- a/lib/uber/builder.rb
+++ b/lib/uber/builder.rb
@@ -39,7 +39,10 @@ module Uber
       end
 
       def call(*args)
-        build_class_for(*args)
+        kls = build_class_for(*args)
+        return kls if kls == @constant
+        return kls unless kls.include?(Uber::Builder)
+        kls.class_builder.call(*args)
       end
 
     private


### PR DESCRIPTION
It seems to be working, I'm just not sure about that: `return kls unless kls.include?(Uber::Builder)`. Is there a better way to know that the class that we want to loads can have builders?