### PR TITLE
change instance_eval style to allow code inspections

### DIFF
--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -2,7 +2,7 @@ module Uber
   module InheritableAttr
 
     def inheritable_attr(name, options={})
-      instance_eval %Q{
+      instance_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{name}=(v)
           @#{name} = v
         end
@@ -11,7 +11,7 @@ module Uber
           return @#{name} if instance_variable_defined?(:@#{name})
           @#{name} = InheritableAttribute.inherit_for(self, :#{name}, #{options})
         end
-      }
+      RUBY
     end
 
     def self.inherit_for(klass, name, options={})


### PR DESCRIPTION
given:
```ruby
class Foo
  extend  Uber::InheritableAttr
  self.inheritable_attr :bar
end
```

before:
```ruby
Foo.method(:bar).source_location # => ["(eval)", 6]
```

after:
```ruby
Foo.method(:bar).source_location # => ["lib/uber/inheritable_attr.rb", 6]
```