### PR TITLE
Prevent modifying static Uber::Options' internals

### DIFF
--- a/lib/uber/options.rb
+++ b/lib/uber/options.rb
@@ -17,7 +17,7 @@ module Uber
 
     # Evaluates every element and returns a hash.  Accepts context and arbitrary arguments.
     def evaluate(context, *args)
-      return @static unless dynamic?
+      return @static.dup unless dynamic?
 
       evaluate_for(context, *args)
     end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -106,6 +106,13 @@ class UberOptionsTest < MiniTest::Spec
         end
         static.evaluate(nil).must_equal({:volume =>1, :style => "Punkrock"})
       end
+
+      it "prevent modifying internals" do
+        evaluated = static.evaluate(nil)
+        evaluated.delete(:volume)
+
+        static.evaluate(nil).must_equal({:volume =>1, :style => "Punkrock"})
+      end
     end
   end
 


### PR DESCRIPTION
Before

``` ruby
options = Uber::Options.new(foo: 'bar')
evaluated = options.evaluate(nil) #=> { foo: 'bar' }
evaluated.delete(:foo) #=> 'bar'

options.evaluate(nil) #= { }
```

Thus, you are able to modify options by the reference! It may be extremely confusing when you pass this options somewhere else

I fixed this, so now this is impossible:

``` ruby
options = Uber::Options.new(foo: 'bar')
evaluated = options.evaluate(nil) #=> { foo: 'bar' }
evaluated.delete(:foo) #=> 'bar'

options.evaluate(nil) #=> { foo: 'bar' }
```
