### PR TITLE
Inherit method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ class Song
 
 This won't `clone` but simply pass the value on to the subclass.
 
+## Inherit method
+
+`::inheritable_attr` uses `Object#clone` method which doesn't work properly for cloning i.e. hashes. You can specify your own inherit method:
+
+```ruby
+require 'active_support/core_ext/object/deep_dup'
+
+class Song
+  extend Uber::InheritableAttr
+  inheritable_attr :properties, inherit_method: :deep_dup
+```
 
 # Dynamic Options
 

--- a/lib/uber/inheritable_attr.rb
+++ b/lib/uber/inheritable_attr.rb
@@ -20,7 +20,12 @@ module Uber
       value = klass.superclass.send(name) # could be nil
 
       return value if options[:clone] == false
-      Clone.(value) # this could be dynamic, allowing other inheritance strategies.
+
+      if options[:inherit_method]
+        value.send(options[:inherit_method])
+      else
+        Clone.(value) # this could be dynamic, allowing other inheritance strategies.
+      end
     end
 
     class Clone

--- a/test/inheritable_attr_test.rb
+++ b/test/inheritable_attr_test.rb
@@ -9,6 +9,9 @@ class InheritableAttrTest < MiniTest::Spec
         inheritable_attr :drinks
         inheritable_attr :glass
         inheritable_attr :guests, clone: false
+
+        inheritable_attr :dj, inherit_method: :dup
+        self.dj = "Paul Oakenfold".freeze
       end
     }
 
@@ -86,6 +89,13 @@ class InheritableAttrTest < MiniTest::Spec
       subklass = Class.new(subject)
 
       subklass.glass.must_equal false
+    end
+
+    it "respects :inherit_method" do
+      class B < subject
+      end
+
+      refute B.dj.frozen?
     end
   end
 end


### PR DESCRIPTION
Hello there!

I added `inherit_method` because of this:

``` ruby
require 'uber/inheritable_attr'

class A
 extend Uber::InheritableAttr

 inheritable_attr :shallow
 self.shallow = { common: {} }
end

class B < A
end

class C < A
end

B.shallow[:common][:this] = "Should be in C"
p C.shallow # => {:common=>{:this=>"shouldn't be in C"}}
```