### PR TITLE
Travis: use jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.1
-  - jruby-19mode
-  - jruby
+  - jruby-9.1.13.0
 before_install:
   - gem install bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html